### PR TITLE
feat : 이미지 캐러셀 구현

### DIFF
--- a/components/atoms/ImagesCarousel.tsx
+++ b/components/atoms/ImagesCarousel.tsx
@@ -1,0 +1,52 @@
+import Image from "next/image";
+import { useState } from "react";
+
+// Import Swiper React components
+import { Swiper, SwiperSlide } from "swiper/react";
+
+// import required modules
+import { Pagination, Navigation } from "swiper/modules";
+
+// Import Swiper styles
+import "swiper/css";
+import "swiper/css/pagination";
+import "swiper/css/navigation";
+
+const ImagesCarouse = ({ imageArray }: { imageArray: string[] }) => {
+  const [isCover, setIsCover] = useState(true);
+
+  return (
+    <>
+      <Swiper
+        slidesPerView={1}
+        spaceBetween={30}
+        loop={true}
+        pagination={{
+          clickable: true,
+        }}
+        navigation={true}
+        modules={[Pagination, Navigation]}
+        className="mySwiper bg-gray-40 h-[30vh] w-full"
+      >
+        {imageArray.map((item, i) => {
+          return (
+            <SwiperSlide key={i}>
+              <div className="relative h-[30vh] w-full flex items-center justify-center">
+                <Image
+                  onClick={() => {
+                    setIsCover((prevValue) => !prevValue);
+                  }}
+                  className={`${isCover ? "object-cover" : "object-contain"}`}
+                  src={item}
+                  alt=""
+                  fill
+                ></Image>
+              </div>
+            </SwiperSlide>
+          );
+        })}
+      </Swiper>
+    </>
+  );
+};
+export default ImagesCarouse;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.49.3",
+        "swiper": "^11.0.6",
         "zod": "^3.22.4",
         "zustand": "^4.4.7"
       },
@@ -16969,6 +16970,24 @@
       "peerDependencies": {
         "@swc/core": "^1.2.147",
         "webpack": ">=2"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.0.6",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.0.6.tgz",
+      "integrity": "sha512-W/Me7MQl5rNgdM5x9i3Gll76WsyVpnHn91GhBOyL7RCFUeg62aVnflzlVfIpXzZ/87FtJOfAoDH79ZH2Yq76zA==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/synchronous-promise": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "lint": "eslint --cache ."
   },
   "dependencies": {
-    "@hookform/resolvers": "^3.3.4",
     "@googlemaps/react-wrapper": "^1.1.35",
+    "@hookform/resolvers": "^3.3.4",
     "@tanstack/react-query": "^5.17.15",
     "@tanstack/react-query-devtools": "^5.17.18",
     "axios": "^1.6.5",
@@ -22,6 +22,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.49.3",
+    "swiper": "^11.0.6",
     "zod": "^3.22.4",
     "zustand": "^4.4.7"
   },


### PR DESCRIPTION
## 🛠️ 주요 변경 사항

- [x] 기본 상태는 object-cover인데 사진 클릭하면 object-contain으로 바뀌어서 원본의 사진 디자인을 보여줄 수 있도록 한다
- [x] 캐러셀이 마지막에 도달하면 맨 처음 사진부터 다시 시작한다
- [x] react-swiper 라이브러리를 사용해서 구현했습니다.


## 🖼️ 스크린샷(선택)
<img width="616" alt="스크린샷 2024-02-08 오후 10 30 57" src="https://github.com/Odagada/Trimo-FE/assets/144667387/5266b9e5-5feb-4b0c-9fd6-80aad9b74692">
<img width="620" alt="스크린샷 2024-02-08 오후 10 31 02" src="https://github.com/Odagada/Trimo-FE/assets/144667387/d8c2bb86-552b-444d-a353-751d1509a5b8">


```ts
import Carousel from "@/components/atoms/ImagesCarousel";

export default function test() {
  const imageArray = ["/images/photos/a.jpg", "/images/photos/b.jpg", "/images/photos/c.jpg"];

  return <Carousel imageArray={imageArray}></Carousel>;
}
```

이미지가 담긴 array를 통채로 넣어주면 됩니다. 