### PR TITLE
[Refactor] Google Map Multiple Markers

### DIFF
--- a/components/atoms/MapMarker.tsx
+++ b/components/atoms/MapMarker.tsx
@@ -1,28 +1,29 @@
 /* eslint-disable no-undef */
-
 export const addSingleMarkers = ({
-  locationID,
+  locationIDList,
   map,
 }: {
-  locationID: string;
+  locationIDList: string[];
   map: google.maps.Map | null | undefined;
 }) => {
   const service = new google.maps.places.PlacesService(map!);
 
   // Add Marker on Google Map Component
-  service.getDetails({ placeId: locationID }, (result, status) => {
-    map?.setCenter(result?.geometry?.location!);
-    const marker = new google.maps.Marker({
-      map,
-      draggable: true,
-      clickable: true,
-      position: result?.geometry?.location,
-    });
+  locationIDList.map((location, index) => {
+    service.getDetails({ placeId: location }, (result, status) => {
+      index === 0 && map?.setCenter(result?.geometry?.location!);
+      const marker = new google.maps.Marker({
+        map,
+        draggable: true,
+        clickable: true,
+        position: result?.geometry?.location,
+      });
 
-    // Evoke Zoom Effect when Marker Clicked
-    google.maps.event.addListener(marker, "click", () => {
-      map?.setZoom(18);
-      map?.setCenter(marker.getPosition()!);
+      // Evoke Zoom Effect when Marker Clicked
+      google.maps.event.addListener(marker, "click", () => {
+        map?.setZoom(18);
+        map?.setCenter(marker.getPosition()!);
+      });
     });
   });
 };

--- a/components/molecules/GoogleMapContent.tsx
+++ b/components/molecules/GoogleMapContent.tsx
@@ -1,13 +1,10 @@
 import useDrawGoogleMap from "@/hooks/useDrawGoogleMap";
+import { MapProps } from "@/types/client.types";
 import React from "react";
 
-export interface MapContentProps {
-  locationID: string;
-}
-
-export const GoogleMapContent = ({ locationID }: MapContentProps) => {
+export const GoogleMapContent = ({ locationIDList }: MapProps) => {
   // Google Map Reference
-  const googleMapRef = useDrawGoogleMap({ locationID });
+  const googleMapRef = useDrawGoogleMap({ locationIDList });
 
   return <div ref={googleMapRef} className="w-[792px] h-[430px]" />; // 구글 지도 컴포넌트
 };

--- a/components/organisms/GoogleMap.tsx
+++ b/components/organisms/GoogleMap.tsx
@@ -2,12 +2,9 @@ import React from "react";
 import { Wrapper, Status } from "@googlemaps/react-wrapper";
 import Spinner from "@/components/atoms/Spinner";
 import GoogleMapContent from "@/components/molecules/GoogleMapContent";
+import { MapProps } from "@/types/client.types";
 
-interface MapProps {
-  locationID?: string; // Google Location ID to find
-}
-
-function GoogleMap({ locationID }: MapProps) {
+function GoogleMap({ locationIDList }: MapProps) {
   const apiKey = "AIzaSyCXXqxV548C4DL_qcOdDWIIqHvRwnl97rY";
 
   if (!apiKey) {
@@ -22,7 +19,7 @@ function GoogleMap({ locationID }: MapProps) {
   return (
     <Wrapper apiKey={apiKey} libraries={["places"]} render={render}>
       {" "}
-      <GoogleMapContent locationID={locationID || ""} />
+      <GoogleMapContent locationIDList={locationIDList || [""]} />
     </Wrapper>
   );
 }

--- a/hooks/useDrawGoogleMap.tsx
+++ b/hooks/useDrawGoogleMap.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable no-undef */
 import { useEffect, useRef } from "react";
-import { MapContentProps } from "@/components/molecules/GoogleMapContent";
 import { addSingleMarkers } from "@/components/atoms/MapMarker";
+import { MapProps } from "@/types/client.types";
 
 const DEFAULT_CENTER = { lat: 37.5519, lng: 126.9918 }; // default center 좌표 값 - 대한민국 서울 좌표
-const DEFAULT_ZOOM = 4; // zoom 설정 값
+const DEFAULT_MARKER_ZOOM = 4; // zoom 설정 값
 
-const useDrawGoogleMap = ({ locationID }: MapContentProps) => {
+const useDrawGoogleMap = ({ locationIDList }: MapProps) => {
   const ref = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -14,13 +14,13 @@ const useDrawGoogleMap = ({ locationID }: MapContentProps) => {
     if (ref.current) {
       const map = new window.google.maps.Map(ref.current, {
         center: DEFAULT_CENTER,
-        zoom: DEFAULT_ZOOM,
+        zoom: DEFAULT_MARKER_ZOOM,
       });
 
       // Add Single Marker On the Google Map with Place ID
-      addSingleMarkers({ locationID, map }); // PlaceID로 지도에 마커 표시
+      addSingleMarkers({ locationIDList, map }); // PlaceID로 지도에 마커 표시
     }
-  }, [locationID]);
+  }, [locationIDList]);
 
   return ref;
 };

--- a/hooks/useDrawGoogleMap.tsx
+++ b/hooks/useDrawGoogleMap.tsx
@@ -4,7 +4,8 @@ import { addSingleMarkers } from "@/components/atoms/MapMarker";
 import { MapProps } from "@/types/client.types";
 
 const DEFAULT_CENTER = { lat: 37.5519, lng: 126.9918 }; // default center 좌표 값 - 대한민국 서울 좌표
-const DEFAULT_MARKER_ZOOM = 4; // zoom 설정 값
+const SINGLE_MARKER_ZOOM = 12; // zoom 설정 값
+const MULTIPLE_MARKER_ZOOM = 4;
 
 const useDrawGoogleMap = ({ locationIDList }: MapProps) => {
   const ref = useRef<HTMLDivElement | null>(null);
@@ -14,7 +15,7 @@ const useDrawGoogleMap = ({ locationIDList }: MapProps) => {
     if (ref.current) {
       const map = new window.google.maps.Map(ref.current, {
         center: DEFAULT_CENTER,
-        zoom: DEFAULT_MARKER_ZOOM,
+        zoom: locationIDList.length > 1 ? MULTIPLE_MARKER_ZOOM : SINGLE_MARKER_ZOOM,
       });
 
       // Add Single Marker On the Google Map with Place ID

--- a/pages/review/[id].tsx
+++ b/pages/review/[id].tsx
@@ -96,7 +96,7 @@ const ReadReview = ({ reviewId, spotId }: InferGetServerSidePropsType<typeof get
 
         {/* map area */}
         <div className="mb-73">
-          <GoogleMap locationID={spotData?.data.placeId} />
+          <GoogleMap locationIDList={[spotData?.data.placeId!]} />
         </div>
         {/* tag and createdAt */}
         <div className="flex justify-between items-center mb-155">

--- a/types/client.types.ts
+++ b/types/client.types.ts
@@ -76,3 +76,7 @@ export type ImageType = {
 };
 
 export type OrderValue = "인기순" | "평점순" | "최신순";
+
+export interface MapProps {
+  locationIDList: string[];
+}


### PR DESCRIPTION
## 🛠️ 주요 변경 사항

- [x] google map에 locationID를 배열로 받아 마커 여러개 찍을 수 있도록 구현
- [x] zoom 값 수정, 마커 여러개 일 때는 한국, 미국, 중국 지도가 다 보일 수 있도록 수정, 마커 하나만 있을 때는 보다 확대되어 보일 수 있도록 수정

## 📣 리뷰어에게 하고싶은 말
- 기존 locationID 대신 locationIDList로 사용하시면 됩니다. 마커 한개더라도 배열 형태로 넣어주시면 됩니다!

## 🖼️ 스크린샷(선택)

(1) Single Marker로 구글 지도 사용 할 경우
<img width="1614" alt="Screen Shot 2024-02-17 at 6 04 02 PM" src="https://github.com/Odagada/Trimo-FE/assets/46954114/3bd3de19-95a8-4452-999f-be4a7028f728">

(2) Multiple Marker로 구글 지도 사용 할 경우
<img width="1487" alt="Screen Shot 2024-02-17 at 6 02 05 PM" src="https://github.com/Odagada/Trimo-FE/assets/46954114/cf3b1546-8406-4557-ad5e-24e7f0efcc55">
d592f9-9e5d-4bc2-835e-35b37aba862b">
